### PR TITLE
Fix for signatures with two or more strokes

### DIFF
--- a/SignaturePad-Library/src/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/SignaturePad-Library/src/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -89,6 +89,7 @@ public class SignaturePad extends View
             TimedPoint endPoint = curve.endPoint;
 
             float velocity = endPoint.velocityFrom(startPoint);
+            velocity = Float.isNaN(velocity) ? 0.0f : velocity;
 
             velocity = mVelocityFilterWeight * velocity
                     + (1 - mVelocityFilterWeight) * mLastVelocity;


### PR DESCRIPTION
This pull request fixes a bug with signatures that have more than one stroke. Prior to this bugfix, if a user lifted the finger or the stylus away from the screen the following strokes will only be drawn at minimum width because the velocity was computed as NaN at the beginning of the next stroke and this error was propagated all over the drawing iterations.

Now, if the velocity is computed as NaN it will be reset to zero because this only occurs at the beginning of a new stroke other than first and at that point, velocity is zero.
