### PR TITLE
Added android-maven plugin

### DIFF
--- a/SignaturePad-Library/build.gradle
+++ b/SignaturePad-Library/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'android-library'
 
-apply plugin: 'android-library'
+apply plugin: 'android-maven'
 
 dependencies {
     compile 'com.github.castorflex.smoothprogressbar:library:0.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:0.13.0'
+        classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }
 


### PR DESCRIPTION
With android-maven plugin android-signaturepad can now be installed in the local maven repository:

    gradle install

In addition its will be possible for others to get it as a maven dependency:
https://jitpack.io/#gcacace/android-signaturepad/1.0.1

once these changes are included in a new release 1.0.1.
