### PR TITLE
Base64 String Encoding for Signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+**NOTICE THIS REPO IS A FORK FROM THE ORIGINAL ONE: [android-signaturepad](https://github.com/gcacace/android-signaturepad)**
+
+**What's added in this fork?**
+
+It adds one `set` and some `get` methods (the equivalents to the ones already defined to work with bitmaps) for getting the signature encoded in a **Base64 string format**.
+
+The idea is to make it easier when sending/getting signatures to/from a server through a webservice, avoiding the need to store them as images and write some logic on the server side to manage them.
+
+Public methods added:
+
+* `getSignatureBase64Encoded()`
+* `getTransparentSignatureBase64Encoded()`
+* `getTransparentSignatureBase64Encoded(boolean trimBlankSpace)`
+* `setSignatureBase64Encoded(String encodedSignature)`
+
+Private methods added:
+
+* `bitmapToBase64(Bitmap bitmap)`: given a `Bitmap` object, returns it encoded as a Base64 string. It uses `Bitmap.CompressFormat.PNG` as a default (that could be easily parametrized anyway).
+* `base64EncodedStringToBitmap(String encodedString)`: reverse case, given a Base64 encoded string, returns the `Bitmap` object.
+
+====================
+
 Android Signature Pad
 ====================
 

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
@@ -11,6 +12,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.RectF;
 import android.util.AttributeSet;
+import android.util.Base64;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -19,6 +21,7 @@ import com.github.gcacace.signaturepad.utils.Bezier;
 import com.github.gcacace.signaturepad.utils.ControlTimedPoints;
 import com.github.gcacace.signaturepad.utils.TimedPoint;
 
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -434,5 +437,32 @@ public class SignaturePad extends View {
         public void onSigned();
 
         public void onClear();
+    }
+
+    public String getSignatureBase64Encoded() {
+        return this.bitmapToBase64(this.getSignatureBitmap());
+    }
+
+    public void setSignatureBase64Encoded(String encodedSignature) {
+        this.setSignatureBitmap(this.base64EncodedStringToBitmap(encodedSignature));
+    }
+
+    public String getTransparentSignatureBase64Encoded() {
+        return this.bitmapToBase64(this.getTransparentSignatureBitmap());
+    }
+
+    public String getTransparentSignatureBase64Encoded(boolean trimBlankSpace) {
+        return this.bitmapToBase64(this.getTransparentSignatureBitmap(trimBlankSpace));
+    }
+
+    private String bitmapToBase64(Bitmap bitmap) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, baos);
+        return Base64.encodeToString(baos.toByteArray(), Base64.DEFAULT);
+    }
+
+    private Bitmap base64EncodedStringToBitmap(String encodedString) {
+        byte[] decodedString = Base64.decode(encodedString, Base64.DEFAULT);
+        return BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
     }
 }


### PR DESCRIPTION
This pull requests adds one `set` and some `get` methods (the equivalents to the ones already defined to work with bitmaps) for getting the signature encoded in a **Base64 string format**.

The idea is to make it easier when sending/getting signatures to/from a server through a webservice, avoiding the need to store them as images and write some logic on the server side to manage them.

Public methods added:

* `getSignatureBase64Encoded()`
* `getTransparentSignatureBase64Encoded()`
* `getTransparentSignatureBase64Encoded(boolean trimBlankSpace)`
* `setSignatureBase64Encoded(String encodedSignature)`

Private methods added:

* `bitmapToBase64(Bitmap bitmap)`: given a `Bitmap` object, returns it encoded as a Base64 string. It uses `Bitmap.CompressFormat.PNG` as a default (that could be easily parametrized anyway).
* `base64EncodedStringToBitmap(String encodedString)`: reverse case, given a Base64 encoded string, returns the `Bitmap` object.