### PR TITLE
Disable Signaturepad

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -142,6 +142,10 @@ public class SignaturePad extends View {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        if (!isEnabled()) {
+            return false;
+        }
+
         float eventX = event.getX();
         float eventY = event.getY();
 

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -142,9 +142,8 @@ public class SignaturePad extends View {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        if (!isEnabled()) {
+        if (!isEnabled())
             return false;
-        }
 
         float eventX = event.getX();
         float eventY = event.getY();


### PR DESCRIPTION
Hey,

I just added the possibility to disable the pad, so an existing signature can be shown without an extra element, because I needed this feature for my own project. Maybe you're interested to pull this in.