### PR TITLE
fix gradle dependency on bintray.properties

### DIFF
--- a/signature-pad/build.gradle
+++ b/signature-pad/build.gradle
@@ -7,7 +7,8 @@ dependencies {
 }
 
 Properties properties = new Properties()
-properties.load(project.rootProject.file('bintray.properties').newDataInputStream())
+final def bintrayPropertiesFile = project.rootProject.file('bintray.properties')
+if (bintrayPropertiesFile.exists()) properties.load(bintrayPropertiesFile.newDataInputStream())
 
 android {
     compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)


### PR DESCRIPTION
as the `bintray.properties` files isn't published, Gradle would complain when checking out the project. This might confuse inexperienced contributors