### PR TITLE
Svg optimizations

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgBuilder.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgBuilder.java
@@ -42,7 +42,7 @@ public class SvgBuilder {
         }
     }
 
-    private final StringBuilder mSvgBuilder = new StringBuilder();
+    private final StringBuilder mSvgPathsBuilder = new StringBuilder();
     private Point mCurrentPathLastPoint = null;
     private Integer mCurrentPathStrokeWidth = null;
 
@@ -50,7 +50,7 @@ public class SvgBuilder {
     }
 
     public void clear() {
-        mSvgBuilder.setLength(0);
+        mSvgPathsBuilder.setLength(0);
         mCurrentPathLastPoint = null;
         mCurrentPathStrokeWidth = null;
     }
@@ -59,13 +59,27 @@ public class SvgBuilder {
         if (isPathStarted()) {
             endPath();
         }
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-                "<svg xmlns=\"http://www.w3.org/2000/svg\" " +
-                "height=\"" + height +
-                "\" width=\"" + width +
-                "\">" +
-                mSvgBuilder.toString() +
-                "</svg>";
+        return (new StringBuilder())
+                .append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n")
+                .append("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" ")
+                .append("\"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">")
+                .append("<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" ")
+                .append("height=\"")
+                .append(height)
+                .append("\" ")
+                .append("width=\"")
+                .append(width)
+                .append("\">")
+                .append("<g ")
+                .append("stroke-linejoin=\"round\" ")
+                .append("stroke-linecap=\"round\" ")
+                .append("fill=\"none\" ")
+                .append("stroke=\"black\"")
+                .append(">")
+                .append(mSvgPathsBuilder)
+                .append("</g>")
+                .append("</svg>")
+                .toString();
     }
 
     public SvgBuilder append(final Bezier curve, final float strokeWidth) {
@@ -87,7 +101,7 @@ public class SvgBuilder {
     }
 
     private void startNewPath(final Point startPoint, final Integer strokeWidth) {
-        mSvgBuilder
+        mSvgPathsBuilder
                 .append("<path ")
                 .append("stroke-width=\"")
                 .append(strokeWidth)
@@ -99,7 +113,7 @@ public class SvgBuilder {
     }
 
     private void addCubicBezierCurve(final Point controlPoint1, final Point controlPoint2, final Point endPoint) {
-        mSvgBuilder
+        mSvgPathsBuilder
                 .append("C")
                 .append(controlPoint1)
                 .append(" ")
@@ -110,13 +124,7 @@ public class SvgBuilder {
     }
 
     private void endPath() {
-        mSvgBuilder
-                .append("\" ")
-                .append("stroke-linejoin=\"round\" ")
-                .append("stroke-linecap=\"round\" ")
-                .append("fill=\"none\" ")
-                .append("stroke=\"#000\" ")
-                .append("/>");
+        mSvgPathsBuilder.append("\"/>");
     }
 
     private boolean isPathStarted() {

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgBuilder.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgBuilder.java
@@ -2,62 +2,20 @@ package com.github.gcacace.signaturepad.utils;
 
 public class SvgBuilder {
 
-    /**
-     * Represent a point as it would be in the generated SVG document.
-     */
-    private class Point {
-
-        /**
-         * string representation of the point
-         */
-        final String svg;
-
-        public Point(TimedPoint point) {
-            // one optimisation is to get rid of decimals as they are mostly non-significant in the
-            // produced SVG image
-            svg = (new StringBuilder())
-                    .append(Math.round(point.x))
-                    .append(",")
-                    .append(Math.round(point.y))
-                    .toString();
-        }
-
-        @Override
-        public String toString() {
-            return svg;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Point point = (Point) o;
-            return svg.equals(point.svg);
-        }
-
-        @Override
-        public int hashCode() {
-            return svg.hashCode();
-        }
-    }
-
     private final StringBuilder mSvgPathsBuilder = new StringBuilder();
-    private Point mCurrentPathLastPoint = null;
-    private Integer mCurrentPathStrokeWidth = null;
+    private SvgPathBuilder mCurrentPathBuilder = null;
 
     public SvgBuilder() {
     }
 
     public void clear() {
         mSvgPathsBuilder.setLength(0);
-        mCurrentPathLastPoint = null;
-        mCurrentPathStrokeWidth = null;
+        mCurrentPathBuilder = null;
     }
 
     public String build(final int width, final int height) {
         if (isPathStarted()) {
-            endPath();
+            appendCurrentPath();
         }
         return (new StringBuilder())
                 .append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n")
@@ -82,51 +40,35 @@ public class SvgBuilder {
 
     public SvgBuilder append(final Bezier curve, final float strokeWidth) {
         final Integer roundedStrokeWidth = Math.round(strokeWidth);
-        final Point curveStartPoint = new Point(curve.startPoint);
-        final Point curveControlPoint1 = new Point(curve.control1);
-        final Point curveControlPoint2 = new Point(curve.control2);
-        final Point curveEndPoint = new Point(curve.endPoint);
+        final SvgPoint curveStartSvgPoint = new SvgPoint(curve.startPoint);
+        final SvgPoint curveControlSvgPoint1 = new SvgPoint(curve.control1);
+        final SvgPoint curveControlSvgPoint2 = new SvgPoint(curve.control2);
+        final SvgPoint curveEndSvgPoint = new SvgPoint(curve.endPoint);
 
-        if (!curveStartPoint.equals(mCurrentPathLastPoint) || !roundedStrokeWidth.equals(mCurrentPathStrokeWidth)) {
-            if (isPathStarted()) {
-                endPath();
-            }
-            startNewPath(curveStartPoint, roundedStrokeWidth);
+        if (!isPathStarted()) {
+            startNewPath(roundedStrokeWidth, curveStartSvgPoint);
         }
 
-        addCubicBezierCurve(curveControlPoint1, curveControlPoint2, curveEndPoint);
+        if (!curveStartSvgPoint.equals(mCurrentPathBuilder.getLastPoint())
+                || !roundedStrokeWidth.equals(mCurrentPathBuilder.getStrokeWidth())) {
+            appendCurrentPath();
+            startNewPath(roundedStrokeWidth, curveStartSvgPoint);
+        }
+
+        mCurrentPathBuilder.append(curveControlSvgPoint1, curveControlSvgPoint2, curveEndSvgPoint);
         return this;
     }
 
-    private void startNewPath(final Point startPoint, final Integer strokeWidth) {
-        mSvgPathsBuilder
-                .append("<path ")
-                .append("stroke-width=\"")
-                .append(strokeWidth)
-                .append("\" ")
-                .append("d=\"M")
-                .append(startPoint);
-        mCurrentPathStrokeWidth = strokeWidth;
-        mCurrentPathLastPoint = startPoint;
+    private void startNewPath(Integer roundedStrokeWidth, SvgPoint curveStartSvgPoint) {
+        mCurrentPathBuilder = new SvgPathBuilder(curveStartSvgPoint, roundedStrokeWidth);
     }
 
-    private void addCubicBezierCurve(final Point controlPoint1, final Point controlPoint2, final Point endPoint) {
-        mSvgPathsBuilder
-                .append("C")
-                .append(controlPoint1)
-                .append(" ")
-                .append(controlPoint2)
-                .append(" ")
-                .append(endPoint);
-        mCurrentPathLastPoint = endPoint;
-    }
-
-    private void endPath() {
-        mSvgPathsBuilder.append("\"/>");
+    private void appendCurrentPath() {
+        mSvgPathsBuilder.append(mCurrentPathBuilder);
     }
 
     private boolean isPathStarted() {
-        return mCurrentPathLastPoint != null;
+        return mCurrentPathBuilder != null;
     }
 
 }

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgBuilder.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgBuilder.java
@@ -61,9 +61,7 @@ public class SvgBuilder {
         }
         return (new StringBuilder())
                 .append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n")
-                .append("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" ")
-                .append("\"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">")
-                .append("<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" ")
+                .append("<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.2\" baseProfile=\"tiny\" ")
                 .append("height=\"")
                 .append(height)
                 .append("\" ")

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPathBuilder.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPathBuilder.java
@@ -9,17 +9,19 @@ package com.github.gcacace.signaturepad.utils;
  */
 public class SvgPathBuilder {
 
-    public static final char SVG_ABSOLUTE_CUBIC_BEZIER_CURVE = 'C';
-    public static final char SVG_MOVE = 'M';
+    public static final Character SVG_ABSOLUTE_CUBIC_BEZIER_CURVE = 'C';
+    public static final Character SVG_MOVE = 'M';
     private final StringBuilder mStringBuilder;
     private final Integer mStrokeWidth;
     private final SvgPoint mStartPoint;
     private SvgPoint mLastPoint;
+    private Character mLastSvgCommand;
 
     public SvgPathBuilder(final SvgPoint startPoint, final Integer strokeWidth) {
         mStrokeWidth = strokeWidth;
         mStartPoint = startPoint;
         mLastPoint = startPoint;
+        mLastSvgCommand = null;
         mStringBuilder = new StringBuilder();
     }
 
@@ -32,8 +34,13 @@ public class SvgPathBuilder {
     }
 
     public SvgPathBuilder append(final SvgPoint controlPoint1, final SvgPoint controlPoint2, final SvgPoint endPoint) {
-        mStringBuilder.append(SVG_ABSOLUTE_CUBIC_BEZIER_CURVE);
+        if (SVG_ABSOLUTE_CUBIC_BEZIER_CURVE.equals(mLastSvgCommand)) {
+            mStringBuilder.append(' ');
+        } else {
+            mStringBuilder.append(SVG_ABSOLUTE_CUBIC_BEZIER_CURVE);
+        }
         mStringBuilder.append(makeAbsoluteCubicBezierCurve(controlPoint1, controlPoint2, endPoint));
+        mLastSvgCommand = SVG_ABSOLUTE_CUBIC_BEZIER_CURVE;
         mLastPoint = endPoint;
         return this;
     }

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPathBuilder.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPathBuilder.java
@@ -1,15 +1,14 @@
 package com.github.gcacace.signaturepad.utils;
 
 
-
 /**
  * Build a SVG path as a string.
- *
+ * <p/>
  * https://www.w3.org/TR/SVGTiny12/paths.html
  */
 public class SvgPathBuilder {
 
-    public static final Character SVG_ABSOLUTE_CUBIC_BEZIER_CURVE = 'C';
+    public static final Character SVG_RELATIVE_CUBIC_BEZIER_CURVE = 'c';
     public static final Character SVG_MOVE = 'M';
     private final StringBuilder mStringBuilder;
     private final Integer mStrokeWidth;
@@ -34,13 +33,8 @@ public class SvgPathBuilder {
     }
 
     public SvgPathBuilder append(final SvgPoint controlPoint1, final SvgPoint controlPoint2, final SvgPoint endPoint) {
-        if (SVG_ABSOLUTE_CUBIC_BEZIER_CURVE.equals(mLastSvgCommand)) {
-            mStringBuilder.append(' ');
-        } else {
-            mStringBuilder.append(SVG_ABSOLUTE_CUBIC_BEZIER_CURVE);
-        }
-        mStringBuilder.append(makeAbsoluteCubicBezierCurve(controlPoint1, controlPoint2, endPoint));
-        mLastSvgCommand = SVG_ABSOLUTE_CUBIC_BEZIER_CURVE;
+        mStringBuilder.append(makeRelativeCubicBezierCurve(controlPoint1, controlPoint2, endPoint));
+        mLastSvgCommand = SVG_RELATIVE_CUBIC_BEZIER_CURVE;
         mLastPoint = endPoint;
         return this;
     }
@@ -60,13 +54,38 @@ public class SvgPathBuilder {
                 .toString();
     }
 
-    private String makeAbsoluteCubicBezierCurve(final SvgPoint controlPoint1, final SvgPoint controlPoint2, final SvgPoint endPoint) {
-        return (new StringBuilder())
-                .append(controlPoint1)
-                .append(" ")
-                .append(controlPoint2)
-                .append(" ")
-                .append(endPoint)
-                .toString();
+    private String makeRelativeCubicBezierCurve(final SvgPoint controlPoint1, final SvgPoint controlPoint2, final SvgPoint endPoint) {
+        final String sControlPoint1 = controlPoint1.toRelativeCoordinates(mLastPoint);
+        final String sControlPoint2 = controlPoint2.toRelativeCoordinates(mLastPoint);
+        final String sEndPoint = endPoint.toRelativeCoordinates(mLastPoint);
+
+        final StringBuilder sb = new StringBuilder();
+        if (!SVG_RELATIVE_CUBIC_BEZIER_CURVE.equals(mLastSvgCommand)) {
+            sb.append(SVG_RELATIVE_CUBIC_BEZIER_CURVE);
+            sb.append(sControlPoint1);
+        } else {
+            if (!sControlPoint1.startsWith("-")) {
+                sb.append(" ");
+            }
+            sb.append(sControlPoint1);
+        }
+
+        if (!sControlPoint2.startsWith("-")) {
+            sb.append(" ");
+        }
+        sb.append(sControlPoint2);
+
+        if (!sEndPoint.startsWith("-")) {
+            sb.append(" ");
+        }
+        sb.append(sEndPoint);
+
+        // discard zero curve
+        final String svg = sb.toString();
+        if ("c0 0 0 0 0 0".equals(svg)) {
+            return "";
+        } else {
+            return svg;
+        }
     }
 }

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPathBuilder.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPathBuilder.java
@@ -1,0 +1,65 @@
+package com.github.gcacace.signaturepad.utils;
+
+
+
+/**
+ * Build a SVG path as a string.
+ *
+ * https://www.w3.org/TR/SVGTiny12/paths.html
+ */
+public class SvgPathBuilder {
+
+    public static final char SVG_ABSOLUTE_CUBIC_BEZIER_CURVE = 'C';
+    public static final char SVG_MOVE = 'M';
+    private final StringBuilder mStringBuilder;
+    private final Integer mStrokeWidth;
+    private final SvgPoint mStartPoint;
+    private SvgPoint mLastPoint;
+
+    public SvgPathBuilder(final SvgPoint startPoint, final Integer strokeWidth) {
+        mStrokeWidth = strokeWidth;
+        mStartPoint = startPoint;
+        mLastPoint = startPoint;
+        mStringBuilder = new StringBuilder();
+    }
+
+    public final Integer getStrokeWidth() {
+        return mStrokeWidth;
+    }
+
+    public final SvgPoint getLastPoint() {
+        return mLastPoint;
+    }
+
+    public SvgPathBuilder append(final SvgPoint controlPoint1, final SvgPoint controlPoint2, final SvgPoint endPoint) {
+        mStringBuilder.append(SVG_ABSOLUTE_CUBIC_BEZIER_CURVE);
+        mStringBuilder.append(makeAbsoluteCubicBezierCurve(controlPoint1, controlPoint2, endPoint));
+        mLastPoint = endPoint;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return (new StringBuilder())
+                .append("<path ")
+                .append("stroke-width=\"")
+                .append(mStrokeWidth)
+                .append("\" ")
+                .append("d=\"")
+                .append(SVG_MOVE)
+                .append(mStartPoint)
+                .append(mStringBuilder)
+                .append("\"/>")
+                .toString();
+    }
+
+    private String makeAbsoluteCubicBezierCurve(final SvgPoint controlPoint1, final SvgPoint controlPoint2, final SvgPoint endPoint) {
+        return (new StringBuilder())
+                .append(controlPoint1)
+                .append(" ")
+                .append(controlPoint2)
+                .append(" ")
+                .append(endPoint)
+                .toString();
+    }
+}

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPoint.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPoint.java
@@ -29,6 +29,10 @@ class SvgPoint {
         return stringBuilder.toString();
     }
 
+    public String toRelativeCoordinates(final SvgPoint referencePoint) {
+        return (new SvgPoint(x - referencePoint.x, y - referencePoint.y)).toString();
+    }
+
     @Override
     public String toString() {
         return toAbsoluteCoordinates();

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPoint.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPoint.java
@@ -1,0 +1,41 @@
+package com.github.gcacace.signaturepad.utils;
+
+/**
+ * Represent a point as it would be in the generated SVG document.
+ */
+class SvgPoint {
+
+    /**
+     * string representation of the point
+     */
+    final String svg;
+
+    public SvgPoint(TimedPoint point) {
+        // one optimisation is to get rid of decimals as they are mostly non-significant in the
+        // produced SVG image
+        svg = (new StringBuilder())
+                .append(Math.round(point.x))
+                .append(",")
+                .append(Math.round(point.y))
+                .toString();
+    }
+
+    @Override
+    public String toString() {
+        return svg;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SvgPoint svgPoint = (SvgPoint) o;
+        return svg.equals(svgPoint.svg);
+    }
+
+    @Override
+    public int hashCode() {
+        return svg.hashCode();
+    }
+}

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPoint.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/SvgPoint.java
@@ -5,24 +5,33 @@ package com.github.gcacace.signaturepad.utils;
  */
 class SvgPoint {
 
-    /**
-     * string representation of the point
-     */
-    final String svg;
+    final Integer x, y;
 
     public SvgPoint(TimedPoint point) {
         // one optimisation is to get rid of decimals as they are mostly non-significant in the
         // produced SVG image
-        svg = (new StringBuilder())
-                .append(Math.round(point.x))
-                .append(",")
-                .append(Math.round(point.y))
-                .toString();
+        x = Math.round(point.x);
+        y = Math.round(point.y);
+    }
+
+    public SvgPoint(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public String toAbsoluteCoordinates() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(x);
+        if (y >= 0) {
+            stringBuilder.append(" ");
+        }
+        stringBuilder.append(y);
+        return stringBuilder.toString();
     }
 
     @Override
     public String toString() {
-        return svg;
+        return toAbsoluteCoordinates();
     }
 
     @Override
@@ -31,11 +40,16 @@ class SvgPoint {
         if (o == null || getClass() != o.getClass()) return false;
 
         SvgPoint svgPoint = (SvgPoint) o;
-        return svg.equals(svgPoint.svg);
+
+        if (!x.equals(svgPoint.x)) return false;
+        return y.equals(svgPoint.y);
+
     }
 
     @Override
     public int hashCode() {
-        return svg.hashCode();
+        int result = x.hashCode();
+        result = 31 * result + y.hashCode();
+        return result;
     }
 }


### PR DESCRIPTION
implements multiple optimizations in order to **reduce the size** of the produced SVG document: 

- use [SVG grouping](https://www.w3.org/TR/SVG11/struct.html#Groups) to avoid repeating styling attributes
- avoid repeating the same command in sequence
- use _space_ instead of `,` to separate `x`s and `y`s for better xml compression
- use relative coordinates to lower the number of digits required when describing cubic bezier curves
- do not prepend negative numbers with a space (the `-` is enough for SVG parsers to separate numbers)

Also use the [SVG tiny 1.2 profile](https://www.w3.org/TR/SVGTiny12/) to help devices with low hardware