### PR TITLE
Add attr ‘clearOnDoubleClick’,double click to clear pad, this feature is disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Add this dependency to your `pom.xml`:
      android:layout_width="match_parent"
      android:layout_height="match_parent"
      app:penColor="@android:color/black"
+     app:clearOnDoubleClick="true"
      />
     ```
 2. Configure attributes.
@@ -61,6 +62,7 @@ Add this dependency to your `pom.xml`:
  * `maxWidth` - The maximum width of the stroke (default: 7dp).
  * `penColor` - The color of the stroke (default: Color.BLACK).
  * `velocityFilterWeight` - Weight used to modify new velocity based on the previous velocity (default: 0.9).
+ * `clearOnDoubleClick` - Double click to clear pad (default: false) 
 
 3. Configure signature events listener
 

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -48,6 +48,7 @@ public class SignaturePad extends View {
     //Click values
     private long mFirstClick;
     private int mCountClick;
+    private static final int DOUBLE_CLICK_DELAY_MS = 200;
 
     private Paint mPaint = new Paint();
     private Bitmap mSignatureBitmap = null;
@@ -340,7 +341,7 @@ public class SignaturePad extends View {
 
     private boolean isDoubleClick() {
         if (mClearOnDoubleClick) {
-            if (mFirstClick != 0 && System.currentTimeMillis() - mFirstClick > 200) {
+            if (mFirstClick != 0 && System.currentTimeMillis() - mFirstClick > DOUBLE_CLICK_DELAY_MS) {
                 mCountClick = 0;
             }
             mCountClick++;
@@ -348,7 +349,7 @@ public class SignaturePad extends View {
                 mFirstClick = System.currentTimeMillis();
             } else if (mCountClick == 2) {
                 long lastClick = System.currentTimeMillis();
-                if (lastClick - mFirstClick < 200) {
+                if (lastClick - mFirstClick < DOUBLE_CLICK_DELAY_MS) {
                     this.clear();
                     return true;
                 }

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -10,7 +10,6 @@ import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.RectF;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -45,6 +44,10 @@ public class SignaturePad extends View {
     private int mMaxWidth;
     private float mVelocityFilterWeight;
     private OnSignedListener mOnSignedListener;
+    private boolean mClearOnDoubleClick;
+    //Click values
+    private long mFirstClick;
+    private int mCountClick;
 
     private Paint mPaint = new Paint();
     private Bitmap mSignatureBitmap = null;
@@ -64,6 +67,7 @@ public class SignaturePad extends View {
             mMaxWidth = a.getDimensionPixelSize(R.styleable.SignaturePad_maxWidth, convertDpToPx(7));
             mVelocityFilterWeight = a.getFloat(R.styleable.SignaturePad_velocityFilterWeight, 0.9f);
             mPaint.setColor(a.getColor(R.styleable.SignaturePad_penColor, Color.BLACK));
+            mClearOnDoubleClick = a.getBoolean(R.styleable.SignaturePad_clearOnDoubleClick, false);
         } finally {
             a.recycle();
         }
@@ -158,6 +162,7 @@ public class SignaturePad extends View {
             case MotionEvent.ACTION_DOWN:
                 getParent().requestDisallowInterceptTouchEvent(true);
                 mPoints.clear();
+                if (isDoubleClick()) break;
                 mLastTouchX = eventX;
                 mLastTouchY = eventY;
                 addPoint(getNewPoint(eventX, eventY));
@@ -331,6 +336,25 @@ public class SignaturePad extends View {
         }
 
       return Bitmap.createBitmap(mSignatureBitmap, xMin, yMin, xMax - xMin, yMax - yMin);
+    }
+
+    private boolean isDoubleClick() {
+        if (mClearOnDoubleClick) {
+            if (mFirstClick != 0 && System.currentTimeMillis() - mFirstClick > 200) {
+                mCountClick = 0;
+            }
+            mCountClick++;
+            if (mCountClick == 1) {
+                mFirstClick = System.currentTimeMillis();
+            } else if (mCountClick == 2) {
+                long lastClick = System.currentTimeMillis();
+                if (lastClick - mFirstClick < 200) {
+                    this.clear();
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private TimedPoint getNewPoint(float x, float y) {

--- a/signature-pad/src/main/res/values/attrs.xml
+++ b/signature-pad/src/main/res/values/attrs.xml
@@ -5,5 +5,6 @@
         <attr name="maxWidth" format="dimension" />
         <attr name="penColor" format="color" />
         <attr name="velocityFilterWeight" format="float" />
+        <attr name="clearOnDoubleClick" format="boolean"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
usage:
```xml
<com.github.gcacace.signaturepad.views.SignaturePad  
                android:layout_width="fill_parent"  
                android:layout_height="fill_parent"  
                android:id="@+id/signature_pad"  
                signature:clearOnDoubleClick="true"/>
```