### PR TITLE
Added multiple screen orientation support.

### DIFF
--- a/SignaturePad-Example/src/main/AndroidManifest.xml
+++ b/SignaturePad-Example/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name="com.github.gcacace.signaturepad.MainActivity"
-            android:screenOrientation="landscape"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Added multiple screen orientation support using saved states in the view. It was used two new variables, one to hold the savedBitmap to prevent it from making new bitmaps when there wasn't changes (that was making the bitmap smaller at each screen orientation change) and another to flag an edit in the new orientation. I renamed the clear function to clearView to change the edit flag only when the user clicked in the clear button, not just when the old clear function was called (when the screen orientation changes this function is called).
Any suggestions are welcome.
