### PR TITLE
API23: request WRITE_EXTERNAL_STORAGE at runtime

### DIFF
--- a/SignaturePad-Example/src/main/java/com/github/gcacace/signaturepad/MainActivity.java
+++ b/SignaturePad-Example/src/main/java/com/github/gcacace/signaturepad/MainActivity.java
@@ -1,24 +1,36 @@
 package com.github.gcacace.signaturepad;
 
+import android.Manifest;
+import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
-import android.app.Activity;
 import android.os.Environment;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
-import com.github.gcacace.signaturepad.views.SignaturePad;
-import it.gcacace.signaturepad.R;
 
-import java.io.*;
+import com.github.gcacace.signaturepad.views.SignaturePad;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+
+import it.gcacace.signaturepad.R;
 
 public class MainActivity extends Activity {
 
+    private static final int REQUEST_EXTERNAL_STORAGE = 1;
+    private static String[] PERMISSIONS_STORAGE = {Manifest.permission.WRITE_EXTERNAL_STORAGE};
     private SignaturePad mSignaturePad;
     private Button mClearButton;
     private Button mSaveButton;
@@ -26,6 +38,7 @@ public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        verifyStoragePermissions(this);
         setContentView(R.layout.activity_main);
 
         mSignaturePad = (SignaturePad) findViewById(R.id.signature_pad);
@@ -62,18 +75,32 @@ public class MainActivity extends Activity {
             @Override
             public void onClick(View view) {
                 Bitmap signatureBitmap = mSignaturePad.getSignatureBitmap();
-                if(addJpgSignatureToGallery(signatureBitmap)) {
+                if (addJpgSignatureToGallery(signatureBitmap)) {
                     Toast.makeText(MainActivity.this, "Signature saved into the Gallery", Toast.LENGTH_SHORT).show();
                 } else {
                     Toast.makeText(MainActivity.this, "Unable to store the signature", Toast.LENGTH_SHORT).show();
                 }
-                if(addSvgSignatureToGallery(mSignaturePad.getSignatureSvg())) {
+                if (addSvgSignatureToGallery(mSignaturePad.getSignatureSvg())) {
                     Toast.makeText(MainActivity.this, "SVG Signature saved into the Gallery", Toast.LENGTH_SHORT).show();
                 } else {
                     Toast.makeText(MainActivity.this, "Unable to store the SVG signature", Toast.LENGTH_SHORT).show();
                 }
             }
         });
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String permissions[], @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case REQUEST_EXTERNAL_STORAGE: {
+                // If request is cancelled, the result arrays are empty.
+                if (grantResults.length <= 0
+                        || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+                    Toast.makeText(MainActivity.this, "Cannot write images to external storage", Toast.LENGTH_SHORT).show();
+                }
+            }
+        }
     }
 
     public File getAlbumStorageDir(String albumName) {
@@ -121,7 +148,7 @@ public class MainActivity extends Activity {
         try {
             File svgFile = new File(getAlbumStorageDir("SignaturePad"), String.format("Signature_%d.svg", System.currentTimeMillis()));
             OutputStream stream = new FileOutputStream(svgFile);
-            OutputStreamWriter writer  = new OutputStreamWriter(stream);
+            OutputStreamWriter writer = new OutputStreamWriter(stream);
             writer.write(signatureSvg);
             writer.close();
             stream.flush();
@@ -132,5 +159,26 @@ public class MainActivity extends Activity {
             e.printStackTrace();
         }
         return result;
+    }
+
+    /**
+     * Checks if the app has permission to write to device storage
+     * <p/>
+     * If the app does not has permission then the user will be prompted to grant permissions
+     *
+     * @param activity the activity from which permissions are checked
+     */
+    public static void verifyStoragePermissions(Activity activity) {
+        // Check if we have write permission
+        int permission = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+        if (permission != PackageManager.PERMISSION_GRANTED) {
+            // We don't have permission so prompt the user
+            ActivityCompat.requestPermissions(
+                    activity,
+                    PERMISSIONS_STORAGE,
+                    REQUEST_EXTERNAL_STORAGE
+            );
+        }
     }
 }


### PR DESCRIPTION
While testing on Nexus 5 / Android 6.0.1 I discovered the example app was not able to write to the external storage anymore. 

This add the permission request code that needs to be run at runtime as described at http://stackoverflow.com/a/33292700/107049

I'm not sure if this would break older versions of Android