### PR TITLE
Migrate SignaturePad to LinearLayout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,6 @@ buildscript {
 }
 
 allprojects {
-    version = VERSION_NAME
-    group = GROUP
 
     repositories {
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,3 @@
-VERSION_NAME=1.2.1
-VERSION_CODE=121
-GROUP=com.github.gcacace
-
-POM_NAME=Signature Pad
-POM_ARTIFACT_ID=android-signaturepad
-POM_DESCRIPTION=A custom Android View to capture signatures
-POM_URL=https://github.com/gcacace/android-signaturepad
-POM_SCM_URL=https://github.com/gcacace/android-signaturepad
-POM_SCM_CONNECTION=scm:git@github.com:gcacace/android-signaturepad.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:gcacace/android-signaturepad.git
-POM_LICENCE_NAME=The Apache Software License, Version 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENCE_DIST=repo
-POM_DEVELOPER_ID=gcacace
-POM_DEVELOPER_NAME=Gianluca Cacace
-
-ANDROID_BUILD_TARGET_SDK_VERSION=23
-ANDROID_BUILD_TOOLS_VERSION=25.0.1
-ANDROID_BUILD_SDK_VERSION=23
+GROUP=com.flipstudio.signaturepad.android
+VERSION=1.22
+ARTIFACT_ID=signaturepad

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'signaturepad'
 
-include ':signature-pad', ':SignaturePad-Example'
+include ':signature-pad'

--- a/signature-pad/android.gradle
+++ b/signature-pad/android.gradle
@@ -1,0 +1,39 @@
+apply plugin: 'maven-publish'
+
+def getS3Repository() {
+    "s3://maven.flipstudio.net/"
+}
+
+repositories {
+    maven {
+        url getS3Repository()
+        credentials(AwsCredentials) {
+            accessKey AWS_ACCESS_KEY
+            secretKey AWS_SECRET_KEY
+        }
+    }
+
+    jcenter()
+    mavenCentral()
+}
+
+publishing {
+    repositories {
+        maven {
+            url getS3Repository()
+            credentials(AwsCredentials) {
+                accessKey AWS_ACCESS_KEY
+                secretKey AWS_SECRET_KEY
+            }
+        }
+    }
+
+    publications {
+        mavenJava(MavenPublication) {
+            groupId = GROUP
+            artifactId = ARTIFACT_ID
+            version = VERSION
+            artifact("$buildDir/outputs/aar/signature-pad-release.aar")
+        }
+    }
+}

--- a/signature-pad/build.gradle
+++ b/signature-pad/build.gradle
@@ -1,22 +1,41 @@
+
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-dependencies {
+apply plugin: 'com.android.library'
+apply from: 'android.gradle'
 
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.2.3'
+    }
 }
 
-Properties properties = new Properties()
-final def bintrayPropertiesFile = project.rootProject.file('bintray.properties')
-if (bintrayPropertiesFile.exists()) properties.load(bintrayPropertiesFile.newDataInputStream())
-
 android {
-    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
-    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
+        minSdkVersion 14
+        targetSdkVersion 21
+        versionCode 1
+        versionName "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
 
     dataBinding {
@@ -24,87 +43,3 @@ android {
     }
 }
 
-bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
-
-    configurations = ['archives']
-    pkg {
-        repo = "maven"
-        name = project.POM_ARTIFACT_ID
-        desc = project.POM_DESCRIPTION
-        websiteUrl = project.POM_URL
-        vcsUrl = project.POM_SCM_URL
-        licenses = ["Apache-2.0"]
-        publish = true
-
-        version {
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg.passphrase")
-            }
-            mavenCentralSync {
-                sync = true
-                user = properties.getProperty("oss.userToken")
-                password = properties.getProperty("oss.userTokenValue")
-                close = '1'
-            }
-        }
-    }
-}
-
-install {
-    repositories.mavenInstaller {
-        // This generates POM.xml with proper parameters
-        pom {
-            project {
-                packaging 'aar'
-
-                // Add your description here
-                description project.POM_DESCRIPTION
-                name project.POM_NAME
-                url project.POM_URL
-
-                // Set your license
-                licenses {
-                    license {
-                        name project.POM_LICENCE_NAME
-                        url project.POM_LICENCE_URL
-                    }
-                }
-                developers {
-                    developer {
-                        id project.POM_DEVELOPER_ID
-                        name project.POM_DEVELOPER_NAME
-                    }
-                }
-                scm {
-                    connection project.POM_SCM_URL
-                    developerConnection project.POM_SCM_CONNECTION
-                    url project.POM_URL
-
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -14,6 +14,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
 
+import android.widget.LinearLayout;
 import com.github.gcacace.signaturepad.R;
 import com.github.gcacace.signaturepad.utils.Bezier;
 import com.github.gcacace.signaturepad.utils.ControlTimedPoints;
@@ -25,7 +26,7 @@ import com.github.gcacace.signaturepad.view.ViewTreeObserverCompat;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SignaturePad extends View {
+public class SignaturePad extends LinearLayout {
     //View state
     private List<TimedPoint> mPoints;
     private boolean mIsEmpty;
@@ -56,7 +57,7 @@ public class SignaturePad extends View {
 
     //Default attribute values
     private final int DEFAULT_ATTR_PEN_MIN_WIDTH_PX = 3;
-    private final int DEFAULT_ATTR_PEN_MAX_WIDTH_PX = 7;
+    private final int DEFAULT_ATTR_PEN_MAX_WIDTH_PX = 6;
     private final int DEFAULT_ATTR_PEN_COLOR = Color.BLACK;
     private final float DEFAULT_ATTR_VELOCITY_FILTER_WEIGHT = 0.9f;
     private final boolean DEFAULT_ATTR_CLEAR_ON_DOUBLE_CLICK = false;
@@ -68,10 +69,36 @@ public class SignaturePad extends View {
     public SignaturePad(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        TypedArray a = context.getTheme().obtainStyledAttributes(
-                attrs,
-                R.styleable.SignaturePad,
-                0, 0);
+        setWillNotDraw(false);
+
+        setOrientation(VERTICAL);
+        final float scale = getContext().getResources().getDisplayMetrics().density;
+
+        LinearLayout.LayoutParams upperViewParams = new LinearLayout.LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT, 0.25f);
+        final LinearLayout upperLinearLayout = new LinearLayout(context, attrs);
+        upperLinearLayout.setLayoutParams(upperViewParams);
+        addView(upperLinearLayout);
+
+        final LinearLayout.LayoutParams lineViewParams = new LinearLayout.LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                (int) (scale + 0.5f));
+        lineViewParams.leftMargin = (int) (scale * 30);
+        lineViewParams.rightMargin = (int) (scale * 30);
+        final LinearLayout lineView = new LinearLayout(context, attrs);
+        lineView.setLayoutParams(lineViewParams);
+        lineView.setBackgroundColor(getResources().getColor(android.R.color.black));
+        addView(lineView);
+
+        final LinearLayout.LayoutParams lowerViewParams = new LinearLayout.LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT, 0.75f);
+        final LinearLayout lowerLinearLayout = new LinearLayout(context, attrs);
+        lowerLinearLayout.setLayoutParams(lowerViewParams);
+        addView(lowerLinearLayout);
+
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.SignaturePad, 0, 0);
 
         //Configurable parameters
         try {


### PR DESCRIPTION
Basicamente fiz ele ser um LinearLayout ao invés de uma View, e aí adicionei 3 LinearLayouts "vazios", sendo que o do meio é a linha. Não fica pesado porque ele não tem nada pra desenhar dentro e fica fácil de "mover" a linha caso necessário. Daria pra fazer algo mais bonitinho passando a "porcentagem" que a linha tem que ficar de distância com relação ao top/bottom, mas aí é com vocês pra decidirem.
A linha mais importante aqui no código (e que me tomou mais tempo) foi `setWillNotDraw(false);`. Isso porque toda a mágica da library só acontece no método onDraw(), que é chamado pela API interna, e ele só é chamado "por padrão" quando é uma View, e não quando é um LinearLayout ou outra via do tipo. Daí essa setagem obrigado o método a ser chamado.