### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Android Signature Pad is an Android library for drawing smooth signatures. It us
  * Bitmap and SVG support
  * Data Binding
 
-##Installation
+## Installation
 
 Latest version of the library can be found on Maven Central.
 
@@ -41,7 +41,7 @@ Add this dependency to your `pom.xml`:
 </dependency>
 ```
  
-##Usage
+## Usage
 
 *Please see the `/SignaturePad-Example` app for a more detailed code example of how to use the library.*
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
