### PR TITLE
Clear signature when a null bitmap is set

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -271,6 +271,11 @@ public class SignaturePad extends View {
     }
 
     public void setSignatureBitmap(final Bitmap signature) {
+        if(signature == null) {
+            clear();
+            return;
+        }
+
         // View was laid out...
         if (ViewCompat.isLaidOut(this)) {
             clearView();


### PR DESCRIPTION
Currently, if a null bitmap is set, an NPE is thrown. Clearing the signature pad instead is a good idea and makes it easier to use with databinding. What do you think?