### PR TITLE
Timestamp jitter causes strokeWidth to become fixed at minimum

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/TimedPoint.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/TimedPoint.java
@@ -1,5 +1,7 @@
 package com.github.gcacace.signaturepad.utils;
 
+import android.util.Log;
+
 public class TimedPoint {
     public float x;
     public float y;
@@ -13,8 +15,14 @@ public class TimedPoint {
     }
 
     public float velocityFrom(TimedPoint start) {
-        float velocity = distanceTo(start) / (this.timestamp - start.timestamp);
-        if (velocity != velocity) return 0f;
+        long diff = this.timestamp - start.timestamp;
+        if(diff <= 0) {
+            diff = 1;
+        }
+        float velocity = distanceTo(start) / diff;
+        if (Float.isInfinite(velocity) || Float.isNaN(velocity)) {
+            velocity = 0;
+        }
         return velocity;
     }
 

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/TimedPoint.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/utils/TimedPoint.java
@@ -1,7 +1,5 @@
 package com.github.gcacace.signaturepad.utils;
 
-import android.util.Log;
-
 public class TimedPoint {
     public float x;
     public float y;


### PR DESCRIPTION
If the timestamp is equal between two TimedPoints the check for (velocity != velocity) will not catch infinity and SignaturePad.mLastVelocity will get pinned to infinity.

This should fix TimedPoint so it doesn't return an unsafe velocity