### PR TITLE
Provider consumer proguard along with release aar

### DIFF
--- a/signature-pad/build.gradle
+++ b/signature-pad/build.gradle
@@ -17,6 +17,7 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
+        consumerProguardFiles 'proguard-rules-consumer.pro'
     }
 
     dataBinding {

--- a/signature-pad/proguard-rules-consumer.pro
+++ b/signature-pad/proguard-rules-consumer.pro
@@ -1,0 +1,2 @@
+-dontwarn android.databinding.**
+-keep class android.databinding.** { *; }


### PR DESCRIPTION
The change is pretty small, but all the users of the release `aar` will benefit from it.