### PR TITLE
Fix Double Click Detection

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -101,6 +101,10 @@ public class SignaturePad extends View {
 
     }
 
+    public void setClearOnDoubleClick(boolean mClearOnDoubleClick) {
+        this.mClearOnDoubleClick = mClearOnDoubleClick;
+    }
+    
     @Override
     protected Parcelable onSaveInstanceState() {
         Bundle bundle = new Bundle();

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -57,6 +57,7 @@ public class SignaturePad extends View {
     private long mFirstClick;
     private int mCountClick;
     private static final int DOUBLE_CLICK_DELAY_MS = 200;
+    private static final float DOUBLE_CLICK_SQUARED_MOVE_DIST = 75;
 
     //Default attribute values
     private final int DEFAULT_ATTR_PEN_MIN_WIDTH_PX = 3;
@@ -212,7 +213,6 @@ public class SignaturePad extends View {
             case MotionEvent.ACTION_DOWN:
                 getParent().requestDisallowInterceptTouchEvent(true);
                 mPoints.clear();
-                if (isDoubleClick()) break;
                 mLastTouchX = eventX;
                 mLastTouchY = eventY;
                 addPoint(getNewPoint(eventX, eventY));
@@ -224,6 +224,9 @@ public class SignaturePad extends View {
                 break;
 
             case MotionEvent.ACTION_UP:
+                if (this.isDoubleClick(eventX, eventY)) {
+                    break;
+                }
                 resetDirtyRect(eventX, eventY);
                 addPoint(getNewPoint(eventX, eventY));
                 getParent().requestDisallowInterceptTouchEvent(true);
@@ -242,6 +245,12 @@ public class SignaturePad extends View {
                 (int) (mDirtyRect.bottom + mMaxWidth));
 
         return true;
+    }
+
+    private float calculateSquaredDistance(float startX, float startY, float endX, float endY) {
+        float xDist = endX - startX;
+        float yDist = endY - startY;
+        return xDist * xDist + yDist * yDist;
     }
 
     @Override
@@ -404,7 +413,7 @@ public class SignaturePad extends View {
         return Bitmap.createBitmap(mSignatureBitmap, xMin, yMin, xMax - xMin, yMax - yMin);
     }
 
-    private boolean isDoubleClick() {
+    private boolean isDoubleClick(float currentX, float currentY) {
         if (mClearOnDoubleClick) {
             if (mFirstClick != 0 && System.currentTimeMillis() - mFirstClick > DOUBLE_CLICK_DELAY_MS) {
                 mCountClick = 0;
@@ -414,7 +423,8 @@ public class SignaturePad extends View {
                 mFirstClick = System.currentTimeMillis();
             } else if (mCountClick == 2) {
                 long lastClick = System.currentTimeMillis();
-                if (lastClick - mFirstClick < DOUBLE_CLICK_DELAY_MS) {
+                float dist = this.calculateSquaredDistance(mLastTouchX, mLastTouchY, currentX, currentY);
+                if (lastClick - mFirstClick < DOUBLE_CLICK_DELAY_MS && dist < DOUBLE_CLICK_SQUARED_MOVE_DIST) {
                     this.clearView();
                     return true;
                 }


### PR DESCRIPTION
This PR fixes the issues described in #66. This also fixes an additional issue:
If the user lifts the pen to start another stroke (e.g. when writing a T: first the vertical line, then the horizontal line) and less than the double click threshold milliseconds elapsed, the screen was cleared.

This is achieved by calculating the distance between the two click events: The screen is cleared if and only if the distance between two clicks is small (75 squared distance in this implementation) and the time between the clicks is less than the threshold (unchanged compared to master).

If you want me to refactor ̀`isDoubleClick` as discussed in #91, I can do that later this week (and, if wanted, also fix the setIsEmpty issue from #91).
