### PR TITLE
Prevent blank signatures, enable buttons when movement is detected

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -105,7 +105,7 @@ public class SignaturePad extends View {
     protected Parcelable onSaveInstanceState() {
         Bundle bundle = new Bundle();
         bundle.putParcelable("superState", super.onSaveInstanceState());
-        if(this.mHasEditState == null || this.mHasEditState){
+        if (this.mHasEditState == null || this.mHasEditState) {
             this.mBitmapSavedState = this.getTransparentSignatureBitmap();
         }
         bundle.putParcelable("signatureBitmap", this.mBitmapSavedState);
@@ -114,10 +114,9 @@ public class SignaturePad extends View {
 
     @Override
     protected void onRestoreInstanceState(Parcelable state) {
-        if (state instanceof Bundle)
-        {
+        if (state instanceof Bundle) {
             Bundle bundle = (Bundle) state;
-            this.setSignatureBitmap((Bitmap)bundle.getParcelable("signatureBitmap"));
+            this.setSignatureBitmap((Bitmap) bundle.getParcelable("signatureBitmap"));
             this.mBitmapSavedState = bundle.getParcelable("signatureBitmap");
             state = bundle.getParcelable("superState");
         }
@@ -212,18 +211,18 @@ public class SignaturePad extends View {
                 mLastTouchX = eventX;
                 mLastTouchY = eventY;
                 addPoint(getNewPoint(eventX, eventY));
-                if(mOnSignedListener != null) mOnSignedListener.onStartSigning();
+                if (mOnSignedListener != null) mOnSignedListener.onStartSigning();
 
             case MotionEvent.ACTION_MOVE:
                 resetDirtyRect(eventX, eventY);
                 addPoint(getNewPoint(eventX, eventY));
+                setIsEmpty(false);
                 break;
 
             case MotionEvent.ACTION_UP:
                 resetDirtyRect(eventX, eventY);
                 addPoint(getNewPoint(eventX, eventY));
                 getParent().requestDisallowInterceptTouchEvent(true);
-                setIsEmpty(false);
                 break;
 
             default:
@@ -427,7 +426,7 @@ public class SignaturePad extends View {
             timedPoint = new TimedPoint();
         } else {
             // Get point from cache
-            timedPoint = mPointsCache.remove(mCacheSize-1);
+            timedPoint = mPointsCache.remove(mCacheSize - 1);
         }
 
         return timedPoint.set(x, y);
@@ -496,7 +495,7 @@ public class SignaturePad extends View {
         ensureSignatureBitmap();
         float originalWidth = mPaint.getStrokeWidth();
         float widthDelta = endWidth - startWidth;
-        float drawSteps = (float) Math.floor(curve.length());
+        float drawSteps = (float) Math.ceil(curve.length());
 
         for (int i = 0; i < drawSteps; i++) {
             // Calculate the Bezier (x, y) coordinate for this step.
@@ -611,13 +610,15 @@ public class SignaturePad extends View {
         }
     }
 
-    private int convertDpToPx(float dp){
+    private int convertDpToPx(float dp) {
         return Math.round(getContext().getResources().getDisplayMetrics().density * dp);
     }
 
     public interface OnSignedListener {
         void onStartSigning();
+
         void onSigned();
+
         void onClear();
     }
 


### PR DESCRIPTION
This addresses https://github.com/gcacace/android-signaturepad/issues/105

By using Math.floor when determining steps it would round down on almost any small tap and not draw an image.  Changing this to Math.ceil provides a dot there instead now so the bitmap is no longer blank.

Also moved the setIsEmpty(false) to the ACTION_MOVE since that is more representative of a signature actually being performed instead of just assuming an ACTION_UP also created a signature.  This changes the behavior slightly to cause the buttons to enable when a signature is started instead of waiting for the user to lift their finger.