### PR TITLE
resets mLastWidth for bezier-algorithm when brush size is set

### DIFF
--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -159,6 +159,7 @@ public class SignaturePad extends View {
      */
     public void setMinWidth(float minWidth) {
         mMinWidth = convertDpToPx(minWidth);
+        mLastWidth = (mMinWidth + mMaxWidth) / 2f;
     }
 
     /**
@@ -168,6 +169,7 @@ public class SignaturePad extends View {
      */
     public void setMaxWidth(float maxWidth) {
         mMaxWidth = convertDpToPx(maxWidth);
+        mLastWidth = (mMinWidth + mMaxWidth) / 2f;
     }
 
     /**
@@ -183,7 +185,7 @@ public class SignaturePad extends View {
         mSvgBuilder.clear();
         mPoints = new ArrayList<>();
         mLastVelocity = 0;
-        mLastWidth = (mMinWidth + mMaxWidth) / 2;
+        mLastWidth = (mMinWidth + mMaxWidth) / 2f;
 
         if (mSignatureBitmap != null) {
             mSignatureBitmap = null;


### PR DESCRIPTION
Steps to reproduce the issue:

1) Undo changes in this commit
2) Open Signature-Pad
3) Change Min & Max Width to 75%
4) Draw line
5) Reduce Min & Max width to 25%
6) Draw Line

Conclusion: Step 6 draws a line that starts with a dot of 75% width, and after first dot continues with 25% width.

[Imgur depiction of these steps](https://imgur.com/a/j9bBAj6)