### PR TITLE
Address PR #190 review: SVG re-save before layout + legacy saved-state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ consumers of `com.github.gcacace:signature-pad`.
   across repeated rotations.
 - **`SvgBuilder.build()` was not idempotent** — a second call duplicated the last
   stroke. `build()` (and the new `getInnerPaths()`) are now idempotent.
+- **SVG could be dropped on a re-save before layout.** If a restored pad was saved
+  again before its first layout pass (a `recreate()`/rotation storm), the PNG was
+  kept but the SVG paths were lost because the builder had not been replayed yet.
+  The save path now falls back to the staged restored paths, so `getSignatureSvg()`
+  survives repeated restores.
+- **Saved state from older library versions is honoured.** State written by a
+  pre-1.4.0 version stored the signature as a raw `Bitmap` under `signatureBitmap`;
+  restore now reads that legacy key (safe — the crash was at save time, not
+  restore) instead of silently losing the signature.
 
 ### Added
 - `SvgBuilder.getInnerPaths()` / `restorePaths(String)` — additive helpers used to

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -193,7 +193,18 @@ public class SignaturePad extends View {
                         // own without affecting the raster restore. The paths are in
                         // the CURRENT view coordinate space; the dimensions give the
                         // restored SVG a self-consistent viewBox.
+                        // Prefer the live builder, but fall back to paths staged by a
+                        // prior restore that have not been replayed yet: after
+                        // onRestoreInstanceState the view may be saved AGAIN before its
+                        // first layout pass (a recreate/rotation storm), at which point
+                        // mSvgBuilder is still empty while mRestoredSvgPaths holds the
+                        // signature. Without this fallback the PNG would persist but the
+                        // SVG would be dropped, leaving getSignatureSvg() empty after the
+                        // next restore.
                         String svgPaths = mSvgBuilder.getInnerPaths();
+                        if ((svgPaths == null || svgPaths.isEmpty()) && mRestoredSvgPaths != null) {
+                            svgPaths = mRestoredSvgPaths;
+                        }
                         if (svgPaths != null && !svgPaths.isEmpty()) {
                             // Measure the actual UTF-8 byte length so the comparison
                             // matches the byte-defined cap even if the SVG ever carries
@@ -253,6 +264,17 @@ public class SignaturePad extends View {
                     this.mRestoredSvgHeight = bundle.getInt("signatureSvgHeight", 0);
                     this.mBitmapSavedState = signature;
                     this.setSignatureBitmap(signature);
+                }
+            } else {
+                // Backwards compatibility: state produced by an older library version
+                // stored the signature as a raw Bitmap Parcelable under
+                // "signatureBitmap". Reading it back is safe — the crash this release
+                // fixes happened at SAVE time (parcelling the Bitmap), not on restore —
+                // so honour that legacy key rather than silently losing the signature.
+                Bitmap legacy = bundle.getParcelable("signatureBitmap");
+                if (legacy != null) {
+                    this.mBitmapSavedState = legacy;
+                    this.setSignatureBitmap(legacy);
                 }
             }
             // No saved signature (empty pad, or dropped for exceeding the size

--- a/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
+++ b/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
@@ -386,6 +386,60 @@ public class SignaturePadTest {
     }
 
     @Test
+    public void restoredPad_resavedBeforeLayout_stillPersistsSvgPaths() {
+        // Regression guard (PR #190): after a restore into a not-yet-laid-out pad,
+        // mSvgBuilder is still empty (re-injection is deferred to layout) while the
+        // staged mRestoredSvgPaths holds the signature. A second save before layout
+        // must persist the SVG from the staged paths, not drop it.
+        layout();
+        drawStroke(pad);
+        Parcelable first = pad.onSaveInstanceState();
+        assertNotNull("precondition: first save has SVG paths",
+                ((Bundle) first).getString("signatureSvgPaths"));
+
+        // Restore into a pad that is NOT laid out yet, then save again immediately.
+        SignaturePad restored = newPad();
+        restored.onRestoreInstanceState(first);
+        Parcelable second = restored.onSaveInstanceState();
+
+        assertNotNull("SVG paths must survive a re-save before layout",
+                ((Bundle) second).getString("signatureSvgPaths"));
+
+        // And they must still restore into a real pad as a populated SVG.
+        SignaturePad restored2 = newPad();
+        layout(restored2, 400, 300);
+        restored2.onRestoreInstanceState(second);
+        assertTrue("re-saved SVG restores with paths",
+                restored2.getSignatureSvg().contains("<path "));
+    }
+
+    @Test
+    public void restore_legacyBitmapKey_isHonored() {
+        // Backwards compatibility (PR #190): saved state produced by an older library
+        // version stored the signature as a raw Bitmap Parcelable under
+        // "signatureBitmap". Restoring must honour that legacy key rather than
+        // silently losing the signature (the old crash was at save time, not restore).
+        layout();
+        drawStroke(pad);
+        Bitmap legacyBitmap = pad.getTransparentSignatureBitmap();
+
+        // Build an old-format saved-state Bundle by taking a real one and rewriting
+        // it to the legacy shape: drop the new "signaturePng" key and store the raw
+        // Bitmap under "signatureBitmap", exactly as older library versions did.
+        Bundle legacyState = (Bundle) pad.onSaveInstanceState();
+        legacyState.remove("signaturePng");
+        legacyState.remove("signatureSvgPaths");
+        legacyState.putParcelable("signatureBitmap", legacyBitmap);
+
+        SignaturePad restored = newPad();
+        layout(restored, 400, 300);
+        restored.onRestoreInstanceState(legacyState);
+
+        assertFalse("a legacy Bitmap-key signature must be restored, not lost",
+                restored.isEmpty());
+    }
+
+    @Test
     public void save_overCap_dropsSignatureAndRestoresEmpty() {
         // The size cap is the core crash-prevention mechanism. When the compressed
         // signature exceeds the cap, nothing is persisted and the pad restores


### PR DESCRIPTION
Two saved-state edge cases flagged in PR #190 review:

- SVG dropped on re-save before layout: after restoring into a not-yet-laid-out pad, mSvgBuilder is empty (re-injection is deferred to layout) while the staged mRestoredSvgPaths holds the signature. A second save before that layout pass (recreate/rotation storm) persisted the PNG but dropped the SVG. onSaveInstanceState now falls back to mRestoredSvgPaths when the live builder is empty.
- Backwards-compatible restore: saved state from a pre-1.4.0 version stored the signature as a raw Bitmap under "signatureBitmap". onRestoreInstanceState now reads that legacy key when "signaturePng" is absent (safe — the crash was at save time, not restore), instead of silently losing the signature.

Both gated by mutation-verified tests; 29 SignaturePadTest cases green, lint + assemble clean.