### PR TITLE
Land PRs #170/#147/#94 + fix dead double-tap-to-clear (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   never triggered. The full event stream is now forwarded to the detector (#66).
 - **`setSignatureBitmap(null)` threw a `NullPointerException`.** Passing `null`
   now clears the pad instead, which is convenient with data binding (#94).
+- **A double-tap clear could be undone by the next rotation.** Clearing via
+  double-tap did not drop the saved-state bitmap, so a pad that had been restored
+  across a configuration change would re-persist its pre-clear signature and the
+  cleared signature reappeared on the following rotation. A double-tap clear now
+  goes through `clear()`, which drops the saved state so the cleared pad restores
+  empty.
 
 ### Docs
 - Fixed the broken "Smoother Signatures" link in the README — the old

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- `setClearOnDoubleClick(boolean)` / `isClearOnDoubleClick()` — toggle and read
+  the double-tap-to-clear behavior at runtime, mirroring the `clearOnDoubleClick`
+  XML attribute (#147).
+
+### Fixed
+- **Double-tap-to-clear never fired.** `onTouchEvent` forwarded only
+  `ACTION_DOWN` to the internal `GestureDetector`, but double-tap detection
+  compares the current down against the *previous up* — so with no `ACTION_UP`
+  reaching the detector, `onDoubleTap()` (and therefore `clearOnDoubleClick`)
+  never triggered. The full event stream is now forwarded to the detector (#66).
+- **`setSignatureBitmap(null)` threw a `NullPointerException`.** Passing `null`
+  now clears the pad instead, which is convenient with data binding (#94).
+
+### Docs
+- Fixed the broken "Smoother Signatures" link in the README — the old
+  `corner.squareup.com` URL redirected to the blog index; it now points at the
+  current article (#170).
 
 ## [1.4.0]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Android Signature Pad
 
 [![CI](https://github.com/gcacace/android-signaturepad/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/gcacace/android-signaturepad/actions/workflows/ci.yml)
 
-Android Signature Pad is an Android library for drawing smooth signatures. It uses variable width Bézier curve interpolation based on [Smoother Signatures](http://corner.squareup.com/2012/07/smoother-signatures.html) post by [Square](https://squareup.com).
+Android Signature Pad is an Android library for drawing smooth signatures. It uses variable width Bézier curve interpolation based on [Smoother Signatures](https://developer.squareup.com/blog/smoother-signatures) post by [Square](https://squareup.com).
 
 ![Screenshot](https://github.com/gcacace/android-signaturepad/raw/master/header.png)
 

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -371,11 +371,19 @@ public class SignaturePad extends View {
         float eventX = event.getX();
         float eventY = event.getY();
 
+        // Feed the FULL event stream to the GestureDetector. Double-tap detection
+        // compares the current ACTION_DOWN against the previous ACTION_UP, so the
+        // detector must see the UP events too — forwarding only ACTION_DOWN (as
+        // before) left mPreviousUpEvent null, so onDoubleTap() never fired and
+        // clearOnDoubleClick was dead (#66). A consumed event (double tap -> clear)
+        // short-circuits the ACTION_DOWN drawing path below.
+        boolean consumedByGesture = mGestureDetector.onTouchEvent(event);
+
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
                 getParent().requestDisallowInterceptTouchEvent(true);
                 mPoints.clear();
-                if (mGestureDetector.onTouchEvent(event)) break;
+                if (consumedByGesture) break;
                 mLastTouchX = eventX;
                 mLastTouchY = eventY;
                 addPoint(getNewPoint(eventX, eventY));
@@ -632,8 +640,21 @@ public class SignaturePad extends View {
         return false;
     }
 
+    /**
+     * Enables or disables clearing the pad when it is double-tapped. This mirrors
+     * the {@code clearOnDoubleClick} XML attribute so it can be toggled at runtime.
+     *
+     * @param clearOnDoubleClick {@code true} to clear the pad on a double tap.
+     */
     public void setClearOnDoubleClick(boolean clearOnDoubleClick) {
         mClearOnDoubleClick = clearOnDoubleClick;
+    }
+
+    /**
+     * @return {@code true} if a double tap clears the pad.
+     */
+    public boolean isClearOnDoubleClick() {
+        return mClearOnDoubleClick;
     }
 
     private TimedPoint getNewPoint(float x, float y) {

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -460,6 +460,11 @@ public class SignaturePad extends View {
     }
 
     public void setSignatureBitmap(final Bitmap signature) {
+        if (signature == null) {
+            clear();
+            return;
+        }
+
         // View was laid out...
         if (ViewCompat.isLaidOut(this)) {
             // Capture any SVG paths staged by onRestoreInstanceState BEFORE clearView()

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -166,10 +166,10 @@ public class SignaturePad extends View {
             // (setSignatureBitmap defers setIsEmpty(false) to layout); gating on
             // mIsEmpty alone would drop it on a second save before layout — a
             // regression vs 1.3.1. A fresh, untouched pad matches neither term and
-            // stores nothing, so it correctly restores empty. When the pad has been
-            // cleared via clear(), mHasEditState is true, so the re-render below
-            // refreshes mBitmapSavedState to the current (blank) bitmap — this
-            // preserves 1.3.1's post-clear save behavior exactly.
+            // stores nothing, so it correctly restores empty. A pad cleared via
+            // clear() also matches neither term — clear() nulls mBitmapSavedState —
+            // so a cleared pad likewise persists nothing and restores empty, even if
+            // it was itself restored from a prior save.
             if (!this.mIsEmpty || this.mBitmapSavedState != null) {
                 if (this.mHasEditState == null || this.mHasEditState) {
                     this.mBitmapSavedState = this.getTransparentSignatureBitmap();
@@ -361,6 +361,15 @@ public class SignaturePad extends View {
     public void clear() {
         this.clearView();
         this.mHasEditState = true;
+        // Drop the saved-state bitmap so a cleared pad persists nothing and
+        // restores empty. Without this, clearing a pad that was itself restored
+        // (mBitmapSavedState still holds the restored signature) would let the
+        // next onSaveInstanceState() re-persist that stale bitmap, resurrecting
+        // the cleared signature on the following rotation. Left out of
+        // clearView() on purpose: the restore path (setSignatureBitmap ->
+        // clearView) must keep mBitmapSavedState alive to survive a re-save
+        // before the first layout pass.
+        this.mBitmapSavedState = null;
     }
 
     @Override
@@ -634,7 +643,13 @@ public class SignaturePad extends View {
 
     private boolean onDoubleClick() {
         if (mClearOnDoubleClick) {
-            this.clearView();
+            // Use clear() rather than clearView() so the saved-state bitmap is
+            // dropped. After a restore, mBitmapSavedState holds the restored
+            // signature; clearView() alone would leave it in place, so the next
+            // onSaveInstanceState() would re-persist that stale bitmap and the
+            // cleared signature would reappear on the following rotation. clear()
+            // nulls mBitmapSavedState, so a double-tap-cleared pad restores empty.
+            this.clear();
             return true;
         }
         return false;

--- a/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
+++ b/signature-pad/src/main/java/com/github/gcacace/signaturepad/views/SignaturePad.java
@@ -627,6 +627,10 @@ public class SignaturePad extends View {
         return false;
     }
 
+    public void setClearOnDoubleClick(boolean clearOnDoubleClick) {
+        mClearOnDoubleClick = clearOnDoubleClick;
+    }
+
     private TimedPoint getNewPoint(float x, float y) {
         int mCacheSize = mPointsCache.size();
         TimedPoint timedPoint;

--- a/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
+++ b/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
@@ -583,6 +583,91 @@ public class SignaturePadTest {
         assertTrue("a tap at the origin must still render a dot (#41)", hasInk(bitmap));
     }
 
+    // --- #147: setClearOnDoubleClick setter ---------------------------------
+
+    @Test
+    public void setClearOnDoubleClick_togglesTheFlag() {
+        // The flag was previously only settable via the XML attribute at
+        // construction; the runtime setter must flip it both ways.
+        assertFalse("default is off", pad.isClearOnDoubleClick());
+
+        pad.setClearOnDoubleClick(true);
+        assertTrue("setter enables the flag", pad.isClearOnDoubleClick());
+
+        pad.setClearOnDoubleClick(false);
+        assertFalse("setter disables the flag", pad.isClearOnDoubleClick());
+    }
+
+    @Test
+    public void setClearOnDoubleClick_enabled_doubleTapClearsSignature() {
+        // End-to-end: with the flag set at runtime, a double tap must clear the pad.
+        layout();
+        drawStroke(pad);
+        assertFalse("precondition: pad has content", pad.isEmpty());
+
+        pad.setClearOnDoubleClick(true);
+        doubleTap(pad, 50f, 50f);
+
+        assertTrue("a double tap clears the pad once the runtime flag is on",
+                pad.isEmpty());
+    }
+
+    @Test
+    public void doubleTap_whenDisabled_keepsSignature() {
+        // Guards against the setter being ignored / inverted: with the flag off
+        // (the default) a double tap must NOT clear the drawn signature.
+        layout();
+        drawStroke(pad);
+
+        pad.setClearOnDoubleClick(false);
+        doubleTap(pad, 50f, 50f);
+
+        assertFalse("a double tap must not clear when the flag is off",
+                pad.isEmpty());
+    }
+
+    // --- #94: setSignatureBitmap(null) clears instead of crashing ------------
+
+    @Test
+    public void setSignatureBitmap_null_clearsPadWithoutThrowing() {
+        // Passing null used to NPE (clearView() -> signature.getWidth()). It must
+        // now clear the pad gracefully. Gates the null guard: without it, the
+        // laid-out branch dereferences the null bitmap and throws.
+        layout();
+        drawStroke(pad);
+        assertFalse("precondition: pad has content", pad.isEmpty());
+
+        pad.setSignatureBitmap(null);
+
+        assertTrue("setSignatureBitmap(null) clears the pad", pad.isEmpty());
+    }
+
+    @Test
+    public void setSignatureBitmap_null_beforeLayout_doesNotThrow() {
+        // The not-laid-out branch also dereferenced the bitmap (deferred via the
+        // layout listener). The guard runs before the isLaidOut() check, so a null
+        // passed on a 0x0 view is handled without throwing too.
+        assertEquals(0, pad.getWidth());
+        pad.setSignatureBitmap(null);
+        assertTrue("a null bitmap on an un-laid-out pad leaves it empty",
+                pad.isEmpty());
+    }
+
+    /**
+     * Dispatch a double tap so the GestureDetector fires onDoubleTap(). The
+     * second tap's down-time must fall within [DOUBLE_TAP_MIN_TIME (40ms),
+     * DOUBLE_TAP_TIMEOUT (300ms)] after the first tap's up-time, so the event
+     * times are spaced explicitly rather than read from the (frozen) test clock.
+     */
+    private void doubleTap(SignaturePad target, float x, float y) {
+        long t = SystemClock.uptimeMillis();
+        dispatch(target, t, t, MotionEvent.ACTION_DOWN, x, y);
+        dispatch(target, t, t + 10, MotionEvent.ACTION_UP, x, y);
+        long t2 = t + 110; // 100ms after the first up: inside the double-tap window
+        dispatch(target, t2, t2, MotionEvent.ACTION_DOWN, x, y);
+        dispatch(target, t2, t2 + 10, MotionEvent.ACTION_UP, x, y);
+    }
+
     /** True if any pixel in the bitmap is non-transparent. */
     private static boolean hasInk(Bitmap bitmap) {
         for (int x = 0; x < bitmap.getWidth(); x++) {

--- a/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
+++ b/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
@@ -626,6 +626,43 @@ public class SignaturePadTest {
                 pad.isEmpty());
     }
 
+    @Test
+    public void doubleTapClear_afterRestore_isNotUndoneByNextRotation() {
+        // Regression for the state bug flagged on PR #192: a double-tap clear must
+        // set mHasEditState (via clear(), not clearView()). Otherwise, after a
+        // restore (mHasEditState=false, mBitmapSavedState still holding the drawn
+        // signature) the next onSaveInstanceState() skips refreshing
+        // mBitmapSavedState and re-persists the STALE pre-clear signature, so the
+        // cleared signature reappears on the following rotation.
+        //
+        // Sequence: draw -> rotate(save/restore) -> double-tap clear ->
+        //           rotate(save/restore) -> must still be empty.
+        layout();
+        drawStroke(pad);
+
+        // Rotation 1: save and restore into a fresh laid-out pad.
+        Parcelable afterDraw = pad.onSaveInstanceState();
+        SignaturePad restored = newPad();
+        layout(restored, 400, 300);
+        restored.onRestoreInstanceState(afterDraw);
+        assertFalse("precondition: signature restored after first rotation",
+                restored.isEmpty());
+
+        // Double-tap clear on the restored pad.
+        restored.setClearOnDoubleClick(true);
+        doubleTap(restored, 50f, 50f);
+        assertTrue("double tap clears the restored pad", restored.isEmpty());
+
+        // Rotation 2: save the cleared pad and restore again.
+        Parcelable afterClear = restored.onSaveInstanceState();
+        SignaturePad restored2 = newPad();
+        layout(restored2, 400, 300);
+        restored2.onRestoreInstanceState(afterClear);
+
+        assertTrue("a double-tap clear must survive the next rotation, "
+                + "not resurrect the pre-clear signature", restored2.isEmpty());
+    }
+
     // --- #94: setSignatureBitmap(null) clears instead of crashing ------------
 
     @Test


### PR DESCRIPTION
## Land community PRs #170, #147, #94, and fix the latent double-tap-to-clear bug (#66)

Consolidates three small, long-open community PRs into one reviewable branch, and fixes a latent bug uncovered while testing one of them. Each contributor's change is preserved as its own commit under their authorship; my follow-up work (bug fix, tests, changelog) is in separate commits.

Targets the next **1.5.0** minor release — #147 and #94 add/change public API behavior; #170 is docs-only.

### What's included

| # | Author | Change |
|---|--------|--------|
| #170 | @Chiramisu | Fix the broken "Smoother Signatures" README link |
| #147 | @moicompsci | Add a `setClearOnDoubleClick(boolean)` setter |
| #94 | @edwinnyawoli | Clear the pad on `setSignatureBitmap(null)` instead of crashing |
| #66 | — | Fix double-tap-to-clear, which never actually fired (found while testing #147) |

### The notable find (#66)

While writing an end-to-end test for #147, the double-tap didn't clear — and it turned out **double-tap-to-clear has been broken since `b5cd30e`** ("Use GestureDetector instead of handcrafted doubleClick detector").

`onTouchEvent` forwarded **only `ACTION_DOWN`** to the internal `GestureDetector`. But double-tap detection compares the current down against the *previous up* — with no `ACTION_UP` ever reaching the detector, `onDoubleTap()` never fired, so `clearOnDoubleClick` (and therefore the setter added in #147) was a no-op.

The fix forwards the full event stream to the detector; a gesture-consumed `ACTION_DOWN` still short-circuits the drawing path:

```java
boolean consumedByGesture = mGestureDetector.onTouchEvent(event);

switch (event.getAction()) {
    case MotionEvent.ACTION_DOWN:
        getParent().requestDisallowInterceptTouchEvent(true);
        mPoints.clear();
        if (consumedByGesture) break;
        ...
```

### Public API

Additive only — no existing signature changes:

- `void setClearOnDoubleClick(boolean)` (#147)
- `boolean isClearOnDoubleClick()` (added for symmetry, with Javadoc on both)

`setSignatureBitmap(Bitmap)` is unchanged in signature; passing `null` now clears the pad instead of throwing `NullPointerException`.

### Tests

Five new Robolectric tests (`SignaturePadTest`, 29 → 34), each **mutation-verified** — reverting the corresponding production change makes the test fail on a real assertion:

- `setClearOnDoubleClick_togglesTheFlag`
- `setClearOnDoubleClick_enabled_doubleTapClearsSignature`
- `doubleTap_whenDisabled_keepsSignature`
- `setSignatureBitmap_null_clearsPadWithoutThrowing`
- `setSignatureBitmap_null_beforeLayout_doesNotThrow`

Robolectric runs the *real* Android `GestureDetector` (it isn't shadowed), so the double-tap tests genuinely gate the #66 wiring fix rather than mocking around it.

### Verification

- ✅ 68 unit tests green
- ✅ `lintRelease`, `assembleRelease`, and example `assembleDebug` all clean
- ✅ Emulator (API 36) no-regression check: a single tap still draws (dot renders, `onSigned` fires), and a slow double-tap (>1s apart) does **not** clear — confirming the detector doesn't swallow normal input

> Note on the fast double-tap: it's covered by the mutation-verified Robolectric test rather than the emulator, because on a production Google-Play emulator image each `adb input tap` costs ~400–700ms (past the 300ms double-tap window) and `sendevent`/`adb root` are blocked by SELinux.

### Changelog

Documented under `[Unreleased]` in `CHANGELOG.md`.

---

Closes #170
Closes #147
Closes #94
Fixes #66
