### PR TITLE
Add code coverage (JaCoCo + Codecov) and fix Robolectric attribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,12 @@ jobs:
         run: ./gradlew :signature-pad:jacocoTestReport --stacktrace
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: signature-pad/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
           flags: unittests
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Android Lint (library)
         run: ./gradlew :signature-pad:lintRelease --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,17 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Unit tests (library)
-        run: ./gradlew :signature-pad:testDebugUnitTest --stacktrace
+      - name: Unit tests + coverage (library)
+        run: ./gradlew :signature-pad:jacocoTestReport --stacktrace
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: signature-pad/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          flags: unittests
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Android Lint (library)
         run: ./gradlew :signature-pad:lintRelease --stacktrace

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Android Signature Pad
 ====================
 
 [![CI](https://github.com/gcacace/android-signaturepad/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/gcacace/android-signaturepad/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/gcacace/android-signaturepad/branch/master/graph/badge.svg)](https://codecov.io/gh/gcacace/android-signaturepad)
 
 Android Signature Pad is an Android library for drawing smooth signatures. It uses variable width Bézier curve interpolation based on [Smoother Signatures](https://developer.squareup.com/blog/smoother-signatures) post by [Square](https://squareup.com).
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+# Codecov configuration for android-signaturepad.
+#
+# Coverage is produced by :signature-pad:jacocoTestReport (JaCoCo 0.8.12) and
+# uploaded from CI (see .github/workflows/ci.yml) under the `unittests` flag.
+#
+# Targets are set from the MEASURED coverage (~96% instruction / ~95% line at the
+# time of writing) with margin, so the gate is green today but blocks real
+# regressions. Raise these if coverage climbs; do not set a target you can't meet.
+coverage:
+  precision: 1
+  round: down
+  range: "70...90"
+  status:
+    project:
+      default:
+        target: 90%          # repo-wide floor; well below the measured ~95%
+        threshold: 2%        # tolerate minor fluctuation before failing
+        informational: false # ENFORCING: a drop below (target - threshold) fails the check
+        flags:
+          - unittests
+    patch:
+      default:
+        target: 80%          # new/changed lines held to a solid bar
+        threshold: 5%
+        informational: false
+
+comment:
+  layout: "reason, diff, files"
+  require_changes: false
+
+# Match the CI upload flag so status checks attach to the right report.
+flags:
+  unittests:
+    paths:
+      - signature-pad/src/main/java

--- a/signature-pad/build.gradle
+++ b/signature-pad/build.gradle
@@ -68,6 +68,21 @@ jacoco {
     toolVersion = '0.8.12'
 }
 
+tasks.withType(Test).configureEach {
+    jacoco {
+        // Robolectric loads classes-under-test through its own instrumenting
+        // sandbox classloader; those re-instrumented classes carry no source
+        // location, and JaCoCo drops "no-location classes" by default. Without
+        // this flag SignaturePad reported 0% coverage despite being exercised by
+        // 35 Robolectric tests (the util classes were counted only because their
+        // plain-JUnit tests load through the system classloader). Keep them.
+        includeNoLocationClasses = true
+        // Mandatory on JDK 11+: the coverage agent otherwise chokes on the
+        // bootstrap 'jdk.internal.*' classes ("bogus class" / bad class format).
+        excludes = ['jdk.internal.*']
+    }
+}
+
 tasks.register('jacocoTestReport', JacocoReport) {
     dependsOn 'testDebugUnitTest'
     group = 'verification'

--- a/signature-pad/build.gradle
+++ b/signature-pad/build.gradle
@@ -99,9 +99,11 @@ tasks.register('jacocoTestReport', JacocoReport) {
             '**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*',
             '**/*Test*.*', 'android/**/*.*',
             // Generated data-binding glue — not hand-written code, so exclude it
-            // so the percentage reflects the library's own source.
+            // so the percentage reflects the library's own source. Note:
+            // SignaturePadBindingAdapter is NOT excluded — it is hand-written
+            // public @BindingAdapter API and is covered by its own test.
             '**/databinding/**', '**/BR.*', '**/DataBinderMapperImpl*.*',
-            '**/DataBindingTriggerClass.*', '**/*BindingAdapter*.*'
+            '**/DataBindingTriggerClass.*'
     ]
     def javaClasses = fileTree(dir: "${buildDir}/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: excludes)
     classDirectories.setFrom(files([javaClasses]))

--- a/signature-pad/build.gradle
+++ b/signature-pad/build.gradle
@@ -3,6 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     id 'com.android.library'
     id 'com.vanniktech.maven.publish'
+    id 'jacoco'
 }
 
 android {
@@ -12,6 +13,14 @@ android {
     defaultConfig {
         minSdkVersion 21
         consumerProguardFiles 'proguard-rules-consumer.pro'
+    }
+
+    buildTypes {
+        debug {
+            // Instrument the debug variant so :signature-pad:testDebugUnitTest
+            // emits JaCoCo execution data (consumed by jacocoTestReport below).
+            enableUnitTestCoverage true
+        }
     }
 
     compileOptions {
@@ -51,4 +60,38 @@ mavenPublishing {
     signAllPublications()
 
     coordinates(project.GROUP, 'signature-pad', project.VERSION_NAME)
+}
+
+// Code coverage. AGP's enableUnitTestCoverage produces a JaCoCo .exec file when
+// testDebugUnitTest runs; this task turns it into an XML report Codecov ingests.
+jacoco {
+    toolVersion = '0.8.12'
+}
+
+tasks.register('jacocoTestReport', JacocoReport) {
+    dependsOn 'testDebugUnitTest'
+    group = 'verification'
+    description = 'Generates JaCoCo coverage report for the debug unit tests.'
+
+    reports {
+        xml.required = true   // consumed by Codecov
+        html.required = true  // handy locally
+    }
+
+    // Exclude generated code (data binding, R/BuildConfig) that would otherwise
+    // dilute the numbers.
+    def excludes = [
+            '**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*',
+            '**/*Test*.*', 'android/**/*.*',
+            // Generated data-binding glue — not hand-written code, so exclude it
+            // so the percentage reflects the library's own source.
+            '**/databinding/**', '**/BR.*', '**/DataBinderMapperImpl*.*',
+            '**/DataBindingTriggerClass.*', '**/*BindingAdapter*.*'
+    ]
+    def javaClasses = fileTree(dir: "${buildDir}/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: excludes)
+    classDirectories.setFrom(files([javaClasses]))
+    sourceDirectories.setFrom(files(['src/main/java']))
+    executionData.setFrom(fileTree(dir: buildDir, includes: [
+            'outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec'
+    ]))
 }

--- a/signature-pad/src/test/java/com/github/gcacace/signaturepad/utils/SignaturePadBindingAdapterTest.java
+++ b/signature-pad/src/test/java/com/github/gcacace/signaturepad/utils/SignaturePadBindingAdapterTest.java
@@ -1,0 +1,138 @@
+package com.github.gcacace.signaturepad.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.os.SystemClock;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import com.github.gcacace.signaturepad.views.SignaturePad;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Tests for {@link SignaturePadBindingAdapter}, the hand-written public
+ * {@code @BindingAdapter} API that fans data-binding attributes out to a
+ * {@link SignaturePad.OnSignedListener}. Robolectric is needed because the
+ * adapter installs a listener on a real {@link SignaturePad} whose callbacks
+ * fire from touch dispatch and {@code clear()}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class SignaturePadBindingAdapterTest {
+
+    private Activity activity;
+    private FrameLayout root;
+    private SignaturePad pad;
+
+    @Before
+    public void setUp() {
+        activity = Robolectric.buildActivity(Activity.class).setup().get();
+        root = new FrameLayout(activity);
+        activity.setContentView(root);
+        pad = new SignaturePad(activity, null);
+        pad.setId(View.generateViewId());
+        root.addView(pad);
+        layout(400, 300);
+    }
+
+    @Test
+    public void onStartSigning_adapter_forwardsCallback() {
+        Flag flag = new Flag();
+        SignaturePadBindingAdapter.setOnSignedListener(
+                pad, (SignaturePadBindingAdapter.OnStartSigningListener) () -> flag.fired = true);
+
+        drawStroke();
+
+        assertTrue("the onStartSigning binding adapter must forward the callback",
+                flag.fired);
+    }
+
+    @Test
+    public void onSigned_adapter_forwardsCallback() {
+        Flag flag = new Flag();
+        SignaturePadBindingAdapter.setOnSignedListener(
+                pad, (SignaturePadBindingAdapter.OnSignedListener) () -> flag.fired = true);
+
+        drawStroke();
+
+        assertTrue("the onSigned binding adapter must forward the callback", flag.fired);
+    }
+
+    @Test
+    public void onClear_adapter_forwardsCallback() {
+        Flag flag = new Flag();
+        SignaturePadBindingAdapter.setOnSignedListener(
+                pad, (SignaturePadBindingAdapter.OnClearListener) () -> flag.fired = true);
+
+        pad.clear();
+
+        assertTrue("the onClear binding adapter must forward the callback", flag.fired);
+    }
+
+    @Test
+    public void allListenersNull_areNoOp() {
+        // The combined overload with all-null listeners must install a listener
+        // whose bodies are safe no-ops: drawing and clearing must not throw.
+        SignaturePadBindingAdapter.setOnSignedListener(pad, null, null, null);
+
+        drawStroke();
+        pad.clear();
+
+        assertTrue("clearing leaves the pad empty", pad.isEmpty());
+    }
+
+    @Test
+    public void onlyClearListener_doesNotFireForSigning() {
+        // Guards the per-callback null guards: an onClear-only binding must NOT be
+        // invoked while signing, only on clear.
+        Flag clearFlag = new Flag();
+        SignaturePadBindingAdapter.setOnSignedListener(
+                pad, (SignaturePadBindingAdapter.OnClearListener) () -> clearFlag.fired = true);
+
+        drawStroke();
+        assertFalse("onClear must not fire while signing", clearFlag.fired);
+
+        pad.clear();
+        assertTrue("onClear must fire on clear()", clearFlag.fired);
+    }
+
+    /** Give the pad a real size so touch dispatch produces ink and callbacks. */
+    private void layout(int width, int height) {
+        pad.measure(
+                View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+        pad.layout(0, 0, width, height);
+    }
+
+    /** Draw a short multi-point stroke so the pad fires onStartSigning + onSigned. */
+    private void drawStroke() {
+        long t = SystemClock.uptimeMillis();
+        dispatch(t, t, MotionEvent.ACTION_DOWN, 20f, 20f);
+        for (int i = 1; i <= 8; i++) {
+            dispatch(t, t + i * 10L, MotionEvent.ACTION_MOVE, 20f + i * 15f, 20f + i * 8f);
+        }
+        dispatch(t, t + 90, MotionEvent.ACTION_UP, 140f, 84f);
+    }
+
+    private void dispatch(long downTime, long eventTime, int action, float x, float y) {
+        MotionEvent event = MotionEvent.obtain(downTime, eventTime, action, x, y, 0);
+        try {
+            pad.onTouchEvent(event);
+        } finally {
+            event.recycle();
+        }
+    }
+
+    private static final class Flag {
+        boolean fired;
+    }
+}

--- a/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
+++ b/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
@@ -144,7 +144,7 @@ public class SignaturePadTest {
         layout();
         pad.setPenColor(Color.RED);
 
-        dispatchTouch(pad, 0f, 0f);
+        dispatchTouch(pad, 50f, 50f);
 
         Bitmap bitmap = pad.getTransparentSignatureBitmap();
         assertTrue("a red pen must paint red ink", hasPixelOfColor(bitmap, Color.RED));

--- a/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
+++ b/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
@@ -810,11 +810,22 @@ public class SignaturePadTest {
         return false;
     }
 
-    /** True if any fully-opaque pixel in the bitmap matches the given color. */
+    /** True if any non-transparent pixel in the bitmap approximately matches the given color. */
     private static boolean hasPixelOfColor(Bitmap bitmap, int color) {
+        final int expectedR = Color.red(color);
+        final int expectedG = Color.green(color);
+        final int expectedB = Color.blue(color);
+        final int maxDelta = 10; // tolerate anti-aliasing / blending
+
         for (int x = 0; x < bitmap.getWidth(); x++) {
             for (int y = 0; y < bitmap.getHeight(); y++) {
-                if (bitmap.getPixel(x, y) == color) {
+                int pixel = bitmap.getPixel(x, y);
+                if (Color.alpha(pixel) == 0) {
+                    continue;
+                }
+                if (Math.abs(Color.red(pixel) - expectedR) <= maxDelta
+                        && Math.abs(Color.green(pixel) - expectedG) <= maxDelta
+                        && Math.abs(Color.blue(pixel) - expectedB) <= maxDelta) {
                     return true;
                 }
             }

--- a/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
+++ b/signature-pad/src/test/java/com/github/gcacace/signaturepad/views/SignaturePadTest.java
@@ -135,6 +135,82 @@ public class SignaturePadTest {
         pad.setPenColorRes(android.R.color.black);
     }
 
+    // --- pen configuration ---------------------------------------------------
+
+    @Test
+    public void setPenColor_rendersDotInThatColor() {
+        // setPenColor's effect was never asserted. Set red, tap at the origin (the
+        // zero-length-curve dot branch), and confirm a red pixel was painted.
+        layout();
+        pad.setPenColor(Color.RED);
+
+        dispatchTouch(pad, 0f, 0f);
+
+        Bitmap bitmap = pad.getTransparentSignatureBitmap();
+        assertTrue("a red pen must paint red ink", hasPixelOfColor(bitmap, Color.RED));
+    }
+
+    @Test
+    public void setPenColorRes_invalidResource_fallsBackToBlackWithoutThrowing() {
+        // Resource id 0 is never valid, so getColor throws Resources.NotFoundException;
+        // the catch must fall back to black (#000000) rather than propagate. This
+        // gates the otherwise-uncovered catch branch.
+        layout();
+
+        pad.setPenColorRes(0);
+
+        dispatchTouch(pad, 0f, 0f);
+        Bitmap bitmap = pad.getTransparentSignatureBitmap();
+        assertTrue("the fallback pen must paint black ink",
+                hasPixelOfColor(bitmap, Color.BLACK));
+    }
+
+    @Test
+    public void setMinMaxAndVelocityWeight_thenDraw_stillRenders() {
+        // The three stroke-shaping setters were untested. Exercise them (they also
+        // run convertDpToPx and recompute mLastWidth) and confirm a stroke still
+        // renders afterwards.
+        pad.setMinWidth(2f);
+        pad.setMaxWidth(9f);
+        pad.setVelocityFilterWeight(0.5f);
+        layout();
+
+        drawStroke(pad);
+
+        assertFalse("the pad should have content after drawing", pad.isEmpty());
+        assertTrue("ink should be rendered with the reconfigured widths",
+                hasInk(pad.getTransparentSignatureBitmap()));
+    }
+
+    @Test
+    public void onTouchEvent_whenDisabled_ignoresTouchesAndStaysEmpty() {
+        // The !isEnabled() early return was uncovered. A disabled pad must ignore
+        // touches (onTouchEvent returns false and the pad stays empty).
+        layout();
+        pad.setEnabled(false);
+
+        dispatchTouch(pad, 50f, 50f);
+
+        assertTrue("a disabled pad must ignore touches and stay empty", pad.isEmpty());
+    }
+
+    @Test
+    public void getSignatureBitmap_afterDraw_hasWhiteBackgroundAndInk() {
+        // The white-background composite variant (getSignatureBitmap) had no test.
+        // After drawing it must be non-null, carry the drawn ink, and be painted on
+        // an opaque white background.
+        layout();
+        drawStroke(pad);
+
+        Bitmap bitmap = pad.getSignatureBitmap();
+
+        assertNotNull(bitmap);
+        assertTrue("the white-background bitmap must contain the drawn ink",
+                hasInk(bitmap));
+        assertTrue("the background must be composited white",
+                hasPixelOfColor(bitmap, Color.WHITE));
+    }
+
     // --- listener callbacks --------------------------------------------------
 
     @Test
@@ -145,6 +221,23 @@ public class SignaturePadTest {
         pad.clear();
 
         assertTrue("onClear should fire when the pad is cleared", listener.onClearCalled);
+    }
+
+    @Test
+    public void drawStroke_notifiesOnStartSigningAndOnSigned() {
+        // The onStartSigning (ACTION_DOWN) and onSigned (setIsEmpty(false)) callbacks
+        // were captured by RecordingListener but never asserted anywhere. Drawing a
+        // real stroke must fire both.
+        RecordingListener listener = new RecordingListener();
+        pad.setOnSignedListener(listener);
+        layout();
+
+        drawStroke(pad);
+
+        assertTrue("onStartSigning should fire when the pad is first touched",
+                listener.onStartSigningCalled);
+        assertTrue("onSigned should fire once the pad has content",
+                listener.onSignedCalled);
     }
 
     // --- saved-state: crash fix (#178/#169/#183/#187) ------------------------
@@ -710,6 +803,18 @@ public class SignaturePadTest {
         for (int x = 0; x < bitmap.getWidth(); x++) {
             for (int y = 0; y < bitmap.getHeight(); y++) {
                 if (Color.alpha(bitmap.getPixel(x, y)) != 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** True if any fully-opaque pixel in the bitmap matches the given color. */
+    private static boolean hasPixelOfColor(Bitmap bitmap, int color) {
+        for (int x = 0; x < bitmap.getWidth(); x++) {
+            for (int y = 0; y < bitmap.getHeight(); y++) {
+                if (bitmap.getPixel(x, y) == color) {
                     return true;
                 }
             }


### PR DESCRIPTION
Wires up code-coverage reporting for the library and adds a coverage badge + enforcing Codecov gate. The headline is that reported coverage jumps from **27% → ~96%** — not by writing a mountain of tests, but by fixing a measurement bug that was hiding the coverage the existing 35-test suite already provided.

**No `src/main` behavior changes.** This PR touches only build config, CI, tests, the README badge, and `codecov.yml`.

### The measurement bug (the important part)

The first coverage run reported **27% instruction / 28.8% line**, which looked alarming. It was a tooling artifact, confirmed by dumping the `.exec`: the execution data contained **only the `utils/*` classes** — `SignaturePad` (1642 instructions) showed **0%** despite being exercised by 35 Robolectric tests.

Root cause is the well-known Robolectric + JaCoCo interaction: Robolectric loads classes-under-test through its own instrumenting sandbox classloader; those re-instrumented classes carry no source location, and JaCoCo's agent **drops "no-location classes" by default**. The `utils/*` classes were counted only because their *plain-JUnit* tests load through the system classloader.

The fix (`test: fix JaCoCo coverage attribution…`):

```gradle
tasks.withType(Test).configureEach {
    jacoco {
        includeNoLocationClasses = true
        excludes = ['jdk.internal.*']   // mandatory on JDK 11+
    }
}
```

This one change lifted the repo from **27% → 92.7%** instruction coverage, reflecting tests that already existed.

### New tests (raising the honest number + closing real gaps)

- **SignaturePad** (`SignaturePadTest`, +6): asserts the `onStartSigning`/`onSigned` callbacks (previously captured by the test listener but never actually asserted), `setPenColor` rendering in the chosen color, the `setPenColorRes(invalid)` → black fallback branch, the width/velocity setters, the disabled-pad early-return, and the white-background `getSignatureBitmap()` composite. The three behavioral assertions are **mutation-verified** (reverting the production line makes them fail).
- **SignaturePadBindingAdapter** (`SignaturePadBindingAdapterTest`, new, +5): this is hand-written public `@BindingAdapter` API, not generated glue, so it's un-excluded from coverage and now tested — the `onStartSigning`/`onSigned`/`onClear` fan-out overloads, the all-null no-op path, and the per-callback null guards.

### Coverage config

- **JaCoCo** report task (`jacocoTestReport`) producing the XML Codecov ingests; generated data-binding/R/BuildConfig glue is excluded so the percentage reflects hand-written source.
- **Codecov** upload in CI (via `codecov-action@v5` — the maintainer-recommended line) and a README badge.
- **`codecov.yml`** — enforcing gate with targets derived from the measured number, so it's green today but blocks regressions: **project 90%** (threshold 2%), **patch 80%** (threshold 5%).

### Result

| Metric | Coverage |
|--------|----------|
| Instruction | **95.9%** (2331/2431) |
| Line | **95.5%** (528/553) |
| Branch | **81.0%** (141/174) |
| Method | **92.9%** (79/85) |

**80 unit tests, 0 failures.** Lint + `assembleRelease` + example `assembleDebug` all clean.

### Notes / deliberately out of scope
- No `ControlTimedPointsTest`: that class already reports 100% once attribution is fixed (its earlier 0% was the same measurement bug), so a test would be redundant.
- The `ViewCompat`/`ViewTreeObserverCompat` API < 19 / < 16 legacy branches are unreachable at `minSdk 21` (dead code slated for 2.0 removal) and were not chased.
- The only gap in `SignaturePadBindingAdapter` (90%) is the implicit private constructor of the `final` utility class.

### CI note for reviewers
This is the **first** Codecov upload on a new base, so the `project` status has no baseline to compare against on this PR (Codecov treats the first report as passing). The badge populates and the enforcing gate becomes meaningful once this merges to `master`. `CODECOV_TOKEN` is configured.
